### PR TITLE
feature/Add expireAt field for Firestore Persistence

### DIFF
--- a/src/GenericRateLimiter.ts
+++ b/src/GenericRateLimiter.ts
@@ -72,6 +72,7 @@ export class GenericRateLimiter {
 
         const newRecord: PersistenceRecord = {
             u: recentUsages,
+            expireAt: timestampsSeconds.expireAt
         };
         return newRecord;
     }
@@ -91,11 +92,12 @@ export class GenericRateLimiter {
         return numOfRecentUsages >= this.configuration.maxCalls;
     }
 
-    private getTimestampsSeconds(): { current: number; threshold: number } {
+    private getTimestampsSeconds(): { current: number; threshold: number, expireAt: number } {
         const currentServerTimestampSeconds: number = this.timestampProvider.getTimestampSeconds();
         return {
             current: currentServerTimestampSeconds,
             threshold: currentServerTimestampSeconds - this.configuration.periodSeconds,
+            expireAt: currentServerTimestampSeconds + this.configuration.periodSeconds
         };
     }
 }

--- a/src/persistence/FirestorePersistenceProvider.ts
+++ b/src/persistence/FirestorePersistenceProvider.ts
@@ -70,6 +70,10 @@ export class FirestorePersistenceProvider implements PersistenceProvider {
     private async saveRecord(collectionName: string, recordName: string, record: PersistenceRecord): Promise<void> {
         this.debugFn("Save record collection=" + collectionName + ", document=" + recordName);
         await this.getDocumentRef(collectionName, recordName).set(record);
+        await this.getDocumentRef(collectionName, recordName).set({
+            u: record.u,
+            expireAt: record.expireAt ? admin.firestore.Timestamp.fromMillis(record.expireAt * 1000) : null
+        });
     }
 
     private getDocumentRef(
@@ -82,6 +86,7 @@ export class FirestorePersistenceProvider implements PersistenceProvider {
     private createEmptyRecord(): PersistenceRecord {
         return {
             u: [],
+            expireAt: null
         };
     }
 

--- a/src/persistence/PersistenceProviderMock.ts
+++ b/src/persistence/PersistenceProviderMock.ts
@@ -52,6 +52,7 @@ export class PersistenceProviderMock implements PersistenceProvider {
     private createEmptyRecord(): PersistenceRecord {
         return {
             u: [],
+            expireAt: null
         };
     }
 

--- a/src/persistence/PersistenceRecord.ts
+++ b/src/persistence/PersistenceRecord.ts
@@ -3,6 +3,7 @@ import ow from "ow";
 export interface PersistenceRecord {
     // "u" instead of "usages" to save data transfer
     u: number[];
+    expireAt: number|null;
 }
 
 export namespace PersistenceRecord {

--- a/src/persistence/RealtimeDbPersistenceProvider.ts
+++ b/src/persistence/RealtimeDbPersistenceProvider.ts
@@ -76,6 +76,7 @@ export class RealtimeDbPersistenceProvider implements PersistenceProvider {
     private createEmptyRecord(): PersistenceRecord {
         return {
             u: [],
+            expireAt: null
         };
     }
 }


### PR DESCRIPTION
<!-- The sections suggested are intended to make it easy to create -->
<!-- a descriptive PR that is easy to review. Change as needed! -->

## Motivation / Context

We need the ability to automatically remove entries from Firestore that are no longer in use. Currently, the library does not provide a built-in mechanism to set an expireAt field for Firestore entries. This PR adds expireAt field saved in Firestore that is equal to last usage plus configuration threshold. 

Caution: It is stored only in Firestore as RealtimeDb has no support for TTL.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes or is related to an open issue, link to the issue here. -->

## Description

<!-- Describe your changes in detail. -->
<!-- Do not forget to mention changes to existing parts of the system, direct or indirect. -->

## Testing Instructions / How This Has Been Tested

<!-- Describe how you tested your changes and/or how a reviewer can test your changes. -->

## Notes

<!-- Any additional information that would be helpful to the reviewer. -->

## Documentation

<!-- Do any of the changes warrant documentation updates? -->

<!-- IMPORTANT: Don't forget to link the issue(s), once the PR is created! -->
